### PR TITLE
update content of last two labels to read 'postcode' and 'email'

### DIFF
--- a/app/views/v1/01-start.html
+++ b/app/views/v1/01-start.html
@@ -13,11 +13,12 @@
       </h1>
 
       <p>Use this service to get information about a property in England and Wales, even if you don't own it.</p>
-      <p> Search by postcode to view the:</p>
+
+      <p> Search by postcode to view:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>full address</li>
-          <li>most recent price paid for the property- you won't get this if it was bought before April 2000, if they paid less than £100, or if HM Land Registry have agreed not to record the price </li>
-          <li>title extent for freehold properties</li>
+          <li>the full address</li>
+          <li>the most recent price paid for the property- you won't get this if it was bought before April 2000, if they paid less than £100, or if HM Land Registry have agreed not to record the price </li>
+          <li>the title extent for freehold properties</li>
         </ul>
 
       <p> This information is free. </p>
@@ -44,7 +45,6 @@
             <li>if there's a mortgage and who the lender is</li>
             <li>details of any easements- rights to cross or otherwise use someone else's land for a specified purpose </li>
             <li>details of any restrictive covenants- covenants that impose a restriction on the use of land so that the value and enjoyment of adjoining land will be preserved </li>
-            <li>an official copy of the property deeds</li>
             <li>the title extent for leasehold properties</li>
             <li>a copy of the register</li>
         </ul>

--- a/app/views/v1/05-gov-pay.html
+++ b/app/views/v1/05-gov-pay.html
@@ -70,14 +70,15 @@
       </div>
       <div class="govuk-form-group address">
         <label id="app-postcode-label" class="govuk-label govuk-label--s govuk-!-width-two-thirds">
-          Town or city
+          Postcode
         </label>
         <input id="app-postcode" type="text" name="postcode" class="govuk-input govuk-!-width-one-quarter">
       </div>
       <div class="govuk-form-group address">
         <label id="app-email-label" class="govuk-label govuk-label--s govuk-!-width-two-thirds">
-          Town or city
+          Email
         </label>
+        <span class="govuk-hint govuk-!-margin-bottom-2">We'll send your payment confirmation here</span>
         <input id="app-email" type="email" name="emailk" class="govuk-input govuk-!-width-two-thirds">
       </div>
     </form>


### PR DESCRIPTION
Updated content on Gov pay page as last three labels all said 'town or city'.